### PR TITLE
Use current path by default

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -108,7 +108,7 @@ function load($fileish) {
     }
 
     if (strpos($fileish, ':') === false) {
-        $fileish .= ':composer.lock';
+        $fileish .= ':./composer.lock';
     }
 
     $lines = '';


### PR DESCRIPTION
When you launch the program without options in a directory you have your `composer.lock` in, it will try to make the diff with the `composer.lock` file located in the git root directory.

This patch uses the current directory `composer.lock` file instead (as done with the default `--to` option).