### PR TITLE
from and to: allow http(s) comparison

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -150,7 +150,7 @@ function load($fileish, $base_path = '') {
         $fileish = $base_path . 'composer.lock';
     }
 
-    if (file_exists($fileish)) {
+    if (file_exists($fileish) || url_exists($fileish)) {
         return mustDecodeJson(file_get_contents($fileish), $fileish);
     }
 
@@ -168,6 +168,22 @@ function load($fileish, $base_path = '') {
     }
 
     return mustDecodeJson(implode("\n", $lines), $fileish);
+}
+
+function url_exists($url) {
+	$headers = get_headers(
+		$url,
+		1,
+		stream_context_create(
+			array(
+				'http' => array(
+					'method' => 'HEAD'
+				)
+			)
+		)
+	);
+	krsort($headers);
+	return substr($headers[key($headers)], 9, 3) === '200';
 }
 
 function mustDecodeJson($json, $context) {


### PR DESCRIPTION
Enable the use of http(s) URLs to identify lock files.
Files are already loaded via generic stream wrappers but not all stream wrappers,
http(s) in particular[0], support the used checking ("stat") for the existence of the
file.

Would be happy to supply testing and refactoring beyond this naive solution once the
maintainer outlines some paradigms.

Sample use:
```
./composer-lock-diff --from https://github.com/wikimedia/mediawiki-vendor/raw/REL1_29/composer.lock --to https://github.com/wikimedia/mediawiki-vendor/raw/REL1_30/composer.lock
```

Please note that, for github repositories, you need to provide URLs of the "raw"
version of files to ensure a comparison can be performed.

[0] https://secure.php.net/manual/en/wrappers.http.php#refsect1-wrappers.http-options