### PR TITLE
filter output: show dev or production changes only

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Or from vim, to insert the output into the commit message, type `:r!composer-loc
 - `--json`: json output
 - `--pretty`: pretty output when combined with `--json` (>=5.4 only)
 - `--no-links`: Don't include Compare links in plain text or any links in markdown
+- `--no-dev`: Don't include dev dependency changes. Overrides --dev-only
+- `--dev-only`: Don't include production dependency changes, i.e. show dev changes only
 
 ^ File includes anything available as a [protocol stream wrapper](http://php.net/manual/en/wrappers.php) such as URLs.
 

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -24,8 +24,13 @@ if ($opts['md']) {
     ));
 }
 
-print tableize('Production Changes', $prod, $table_opts);
-print tableize('Dev Changes', $dev, $table_opts);
+if (!$opts['dev-only'] || $opts['no-dev']) {
+    print tableize('Production Changes', $prod, $table_opts);
+}
+
+if (!$opts['no-dev']) {
+    print tableize('Dev Changes', $dev, $table_opts);
+}
 
 function diff($key, $from, $to, $base_path) {
 
@@ -221,7 +226,7 @@ function formatCompareGitlab($url, $from, $to) {
 }
 
 function parseOpts() {
-    $given = getopt('hp:', array('path:', 'from:', 'to:', 'md', 'json', 'pretty', 'no-links', 'help'));
+    $given = getopt('hp:', array('path:', 'from:', 'to:', 'md', 'json', 'pretty', 'no-links', 'help', 'no-dev', 'dev-only'));
 
     foreach(array('help' => 'h', 'path' => 'p') as $long => $short) {
         if (array_key_exists($short, $given)) {
@@ -242,6 +247,8 @@ function parseOpts() {
         'json' => array_key_exists('json', $given),
         'pretty' => version_compare(PHP_VERSION, '5.4.0', '>=') && array_key_exists('pretty', $given),
         'no-links' => array_key_exists('no-links', $given),
+        'no-dev' => array_key_exists('no-dev', $given),
+        'dev-only' => array_key_exists('dev-only', $given),
     );
 }
 
@@ -259,6 +266,8 @@ Options:
   --pretty   Pretty print JSON output (PHP >= 5.4.0)
   --md       Use markdown instead of plain text
   --no-links Don't include Compare links in plain text or any links in markdown
+  --no-dev   Don't include dev dependency changes. Overrides --dev-only
+  --dev-only Don't include production dependency changes, i.e. show dev changes only
 
 EOF;
 


### PR DESCRIPTION
Add options to show dev (`--dev-only`) or production (`--no-dev`) changes
only - to avoid having to filter the output later if only one piece of
information is relevant.

Sample use:
```
./composer-lock-diff --no-dev
```