### PR TITLE
Fix notices when source not available for package

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -182,8 +182,9 @@ function mustDecodeJson($json, $context) {
 }
 
 function makeCompareUrl($pkg, $diff) {
-    $func = 'formatCompare' . ucfirst(getSourceRepoType($pkg->source->url));
-    return call_user_func($func, $pkg->source->url, $diff[$pkg->name][0], $diff[$pkg->name][1]);
+    $sourceUrl = isset($pkg->source->url) ? $pkg->source->url : '';
+    $func = 'formatCompare' . ucfirst(getSourceRepoType($sourceUrl));
+    return call_user_func($func, $sourceUrl, $diff[$pkg->name][0], $diff[$pkg->name][1]);
 }
 
 function getSourceRepoType($url) {


### PR DESCRIPTION
During running this script I have following notices:
```
PHP   1. {main}() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:0
PHP   2. diff() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:6
PHP   3. makeCompareUrl() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:52
PHP Notice:  Undefined property: stdClass::$source in /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 185
PHP Stack trace:
PHP   1. {main}() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:0
PHP   2. diff() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:6
PHP   3. makeCompareUrl() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:52
PHP Notice:  Trying to get property of non-object in /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 185
PHP Stack trace:
PHP   1. {main}() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:0
PHP   2. diff() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:6
PHP   3. makeCompareUrl() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:52
PHP Notice:  Undefined property: stdClass::$source in /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 186
PHP Stack trace:
PHP   1. {main}() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:0
PHP   2. diff() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:6
PHP   3. makeCompareUrl() /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff:52
PHP Notice:  Trying to get property of non-object in /home/ihor/.composer/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 186
```

These issues caused by missing "source" section for some packages. 
For example when you install Magento 2.2.6 via composer - you'll have such packages:
https://devdocs.magento.com/guides/v2.2/install-gde/composer.html

This PR fixing these notices