### PR TITLE
Add support of git@bitbucket.org and git@github.com repos

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -243,7 +243,7 @@ function formatCompareUnknown($url, $from, $to) {
 
 function formatCompareGithub($url, $from, $to) {
     $url = preg_replace(['/\.git$/', '/^git@github.com:/'], ['', 'https://github.com/'], $url);
-    return sprintf('%s/compare/%s...%s', preg_replace('/\.git$/', '', $url), urlencode($from), urlencode($to));
+    return sprintf('%s/compare/%s...%s', $url, urlencode($from), urlencode($to));
 }
 
 function formatCompareBitbucket($url, $from, $to) {

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -214,6 +214,12 @@ function makeCompareUrl($pkg, $diff) {
 }
 
 function getSourceRepoType($url) {
+    if (preg_match('/^git@bitbucket.org:(.*)\.git$/', $url)) {
+        return 'bitbucket';
+    }
+    if (preg_match('/^git@github.com:(.*)\.git$/', $url)) {
+        return 'github';
+    }
     if (! preg_match('/^http/i', $url)) {
         return 'unknown';
     }
@@ -236,11 +242,13 @@ function formatCompareUnknown($url, $from, $to) {
 }
 
 function formatCompareGithub($url, $from, $to) {
+    $url = preg_replace(['/\.git$/', '/^git@github.com:/'], ['', 'https://github.com/'], $url);
     return sprintf('%s/compare/%s...%s', preg_replace('/\.git$/', '', $url), urlencode($from), urlencode($to));
 }
 
 function formatCompareBitbucket($url, $from, $to) {
-    return sprintf('%s/branches/compare/%s%%0D%s', preg_replace('/\.git$/', '', $url), urlencode($from), urlencode($to));
+    $url = preg_replace(['/\.git$/', '/^git@bitbucket.org:/'], ['', 'https://bitbucket.org/'], $url);
+    return sprintf('%s/branches/compare/%s%%0D%s', $url, urlencode($from), urlencode($to));
 }
 
 function formatCompareGitlab($url, $from, $to) {

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -248,7 +248,7 @@ function formatCompareGithub($url, $from, $to) {
 
 function formatCompareBitbucket($url, $from, $to) {
     $url = preg_replace(['/\.git$/', '/^git@bitbucket.org:/'], ['', 'https://bitbucket.org/'], $url);
-    return sprintf('%s/branches/compare/%s%%0D%s', $url, urlencode($from), urlencode($to));
+    return sprintf('%s/branches/compare/%s%%0D%s', $url, urlencode($to), urlencode($from));
 }
 
 function formatCompareGitlab($url, $from, $to) {


### PR DESCRIPTION
This PR adds support of git urls for bitbucket and github for preparing compare URLs

Here is example:
![image](https://user-images.githubusercontent.com/1873745/47772140-60410080-dcee-11e8-8951-5808430dab49.png)
