### PR TITLE
repositories.type: path shows PHP Notice.

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -71,7 +71,7 @@ function diff($key, $from, $to, $base_path) {
 
 function version($pkg)
 {
-    if(substr($pkg->version,0,4) == 'dev-') {
+    if(substr($pkg->version,0,4) == 'dev-' && isset($pkg->source) && isset($pkg->source->reference)) {
         $version = substr($pkg->source->reference,0,7) ?: '';
     } else {
         $version = (string) $pkg->version;


### PR DESCRIPTION
When lock file has a package imported using https://getcomposer.org/doc/05-repositories.md#path, running `composer-lock-diff` generates following notices:
```
PHP Notice:  Undefined property: stdClass::$source in /home/jibran/www/snsw-d8/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 75

Notice: Undefined property: stdClass::$source in /home/jibran/www/snsw-d8/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 75
PHP Notice:  Trying to get property 'reference' of non-object in /home/jibran/www/snsw-d8/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 75

Notice: Trying to get property 'reference' of non-object in /home/jibran/www/snsw-d8/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 75
PHP Notice:  Undefined property: stdClass::$source in /home/jibran/www/snsw-d8/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 75

Notice: Undefined property: stdClass::$source in /home/jibran/www/snsw-d8/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 75
PHP Notice:  Trying to get property 'reference' of non-object in /home/jibran/www/snsw-d8/vendor/davidrjonas/composer-lock-diff/composer-lock-diff on line 75
```