### PR TITLE
Added Drupal packages support.

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -222,6 +222,9 @@ function getSourceRepoType($url) {
     if (preg_match('/^git@gitlab\..+:.+\.git$/', $url)) {
         return 'gitlab';
     }
+    if (preg_match('/^git@git\.drupal\..+:.+\.git$/', $url)) {
+      return 'drupal';
+    }
 
     if (! preg_match('/^http/i', $url)) {
         return 'unknown';
@@ -235,6 +238,8 @@ function getSourceRepoType($url) {
         return 'bitbucket';
     } elseif (strpos($host, 'gitlab') !== false) {
         return 'gitlab';
+    } elseif (strpos($host, 'drupalcode') !== false) {
+      return 'drupal';
     }
 
     return 'unknown';
@@ -266,6 +271,11 @@ function formatCompareGitlab($url, $from, $to) {
     }
     $url = preg_replace('/\.git$/', '', $url);
     return sprintf('%s/compare/%s...%s', $url, urlencode($from), urlencode($to));
+}
+
+function formatCompareDrupal($url, $from, $to) {
+  $url = preg_replace('/\.git$/', '', $url);
+  return sprintf('%s/compare/8.x-%s...8.x-%s', $url, substr(urlencode($from), 0, -2), substr(urlencode($to), 0, -2));
 }
 
 function parseOpts() {


### PR DESCRIPTION
Drupal packages can have following endpoints:

* https://git.drupalcode.org/project/metatag.git
* git@git.drupal.org:project/metatag.git

This PR adds support for [Drupal contributed modules](https://www.drupal.org/docs/develop/using-composer/using-composer-to-install-drupal-and-manage-dependencies#adding-modules).
To support the Drupal 8, a contrib module can have a version like `8.x-1.2`.
Drupal packagist script converts it to semver `1.2.0` to make it compatible with composer package versions.
Right now only Drupal 8 modules can be installed using composer that is why the fix is specific to Druapl 8 version.

Here is the sample output:

| Production Changes         | From    | To       | Compare                                                                      |
|----------------------------|---------|----------|------------------------------------------------------------------------------|
| drupal/metatag             | 1.9.0   | 1.10.0   | [...](https://git.drupalcode.org/project/metatag/compare/8.x-1.9...8.x-1.10) |