### PR TITLE
Fix the detection of dev versions for semver branches

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -69,7 +69,7 @@ function diff($key, $data_from, $data_to) {
 
 function version($pkg)
 {
-    if(substr($pkg->version,0,4) == 'dev-' && isset($pkg->source) && isset($pkg->source->reference)) {
+    if((substr($pkg->version,0,4) == 'dev-' || '-dev' === substr($pkg->version, -4)) && isset($pkg->source) && isset($pkg->source->reference)) {
         $version = substr($pkg->source->reference,0,7) ?: '';
     } else {
         $version = (string) $pkg->version;


### PR DESCRIPTION
Versions like `4.4.x-dev` are versions for branches, that are not prefixes with `dev-`.

This condition is similar to the one used in composer/semver: https://github.com/composer/semver/blob/a951f614bd64dcd26137bc9b7b2637ddcfc57649/src/VersionParser.php#L56