### PR TITLE
Update Gitlab compare URL for Gitlab v16

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -294,7 +294,7 @@ function formatCompareGitlab($url, $from, $to) {
         $url = preg_replace('/^git@(gitlab\.[^:]+):/', 'https://$1/', $url);
     }
     $url = preg_replace('/\.git$/', '', $url);
-    return sprintf('%s/compare/%s...%s', $url, urlencode($from), urlencode($to));
+    return sprintf('%s/-/compare/%s...%s', $url, urlencode($from), urlencode($to));
 }
 
 function formatCompareDrupal($url, $from, $to) {


### PR DESCRIPTION
From Gitlab v16, compare URLs have the new hypen-slash `/-/` path prefix at end of the project path.

Gitlab apparently handles this with a redirect for public repos, but it seems that private repos won't redirect.

Gitlab release notes advise "Update any scripts or bookmarks that reference the legacy URLs."

- https://docs.gitlab.com/ee/update/deprecations.html?removal_milestone=16.0#legacy-urls-replaced-or-removed
- https://gitlab.com/gitlab-org/gitlab/-/issues/28848#release-notes
- `https://gitlab.com/pmjones/fake/compare/0.0.1...0.2.0` before (now a redirect)
- `https://gitlab.com/pmjones/fake/-/compare/0.0.1...0.2.0` after

NB: I ran `make test`, it shows what I think is correct output (`pmjones/fake` "after" URL above), no test updates appear to be required for changed output.
