### PR TITLE
Ensure that the Compare URL uses the appropriate reference where possible

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -318,7 +318,13 @@ function formatCompareGitlab($url, $from, $to) {
 }
 
 function formatCompareDrupal($url, $from, $to) {
-  // Drupalcode uses self-hosted Gitlab now
+  // Drupalcode uses self-hosted Gitlab now.
+  if (strpos($url, 'http') === false) {
+    $url = preg_replace('/^git@(git\.[^:]+):/', 'https://$1/', $url);
+    // git.drupal.org automatically redirects to git.drupalcode.org anyway,
+    // but might as well save the roundtrip.
+    $url = str_replace('://git.drupal.org/', '://git.drupalcode.org/', $url);
+  }
   return formatCompareGitlab($url, $from, $to);
 }
 


### PR DESCRIPTION
This is useful for Drupal packages where they still use `8.x-` type tags.


Previous behaviour:
| Production Changes                              | From          | To              | Compare                                                                                                          |
|-------------------------------------------------|---------------|-----------------|------------------------------------------------------------------------------------------------------------------|
| drupal/token                                    | 1.9.0         | 1.11.0          | [...](https://git.drupalcode.org/project/token/-/compare/1.9.0...1.11.0)                                       |

New behaviour:

| Production Changes                              | From          | To              | Compare                                                                                                          |
|-------------------------------------------------|---------------|-----------------|------------------------------------------------------------------------------------------------------------------|
| drupal/token                                    | 1.9.0         | 1.11.0          | [...](https://git.drupalcode.org/project/token/-/compare/8.x-1.9...8.x-1.11)                                       |