### PR TITLE
git: Add support for loading the composer.lock file relative to the current directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ ehthumbs.db
 Thumbs.db
 /test-project
 /test-data/vendor
+/composer.lock
+/vendor

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -328,6 +328,17 @@ function vcsLoadGit($fileish, $base_path, $_default_fileish) {
     }
 
     if (strpos($fileish, ':') === false) {
+        if (empty($base_path)) {
+            // Resolve from the relative directory.
+            $git_dir = findUp('.', '.git');
+            if ($git_dir) {
+                $project_dir = dirname($git_dir) . DIRECTORY_SEPARATOR;
+                $current_working_dir = getcwd();
+                if (substr( $current_working_dir, 0, strlen($project_dir)) === $project_dir) {
+                    $base_path = substr($current_working_dir, strlen($project_dir)) . DIRECTORY_SEPARATOR;
+                }
+            }
+        }
         $fileish .= ':' . $base_path . 'composer.lock';
     }
 

--- a/test-git.sh
+++ b/test-git.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+git --help > /dev/null || { echo "Fail: could not find 'git' executable"; exit 1; }
+
+trap cleanup INT ERR
+
+function cleanup() {
+  cd "$DIR/test-data"
+  rm -rf proj proj-working gitrepo
+}
+
+set -eEx
+
+cd test-data
+
+mkdir -p proj/trunk
+
+cp composer.from.json proj/trunk/composer.json
+cp composer.from.lock proj/trunk/composer.lock
+
+cp -r proj gitrepo
+cd gitrepo && \
+  git init && \
+  git add . && \
+  git commit -m "initial commit" && \
+  cd ..
+
+git clone file://$PWD/gitrepo proj-working
+cp composer.to.json proj-working/trunk/composer.json
+cp composer.to.lock proj-working/trunk/composer.lock
+
+cd proj-working/trunk
+../../../composer-lock-diff
+
+cd ..
+../../composer-lock-diff -p trunk
+
+cd ..
+rm -rf proj proj-working gitrepo
+


### PR DESCRIPTION
Ignore the composer.lock and vendor directory.

Github codespaces automatically does a composer install.