### PR TITLE
Separate tables for changes in direct and indirect dependencies

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -279,6 +279,9 @@ function mustDecodeJson($json, $context) {
 
 function markDirectDependencies($lock, $json) {
     foreach (array('', '-dev') as $ext) {
+        if (!isset($json->{'require'.$ext})) {
+            continue;
+        }
         foreach ($json->{'require'.$ext} as $pkg => $_) {
             $packages = 'packages'.$ext;
 

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -47,12 +47,12 @@ function diff($key, $data_from, $data_to) {
     $pkgs = array();
 
     foreach($data_from->$key as $pkg) {
-        $pkgs[$pkg->name] = array(version($pkg), 'REMOVED', '');
+        $pkgs[$pkg->name] = array(version($pkg), 'REMOVED', '', array('direct' => property_exists($pkg, 'direct')));
     }
 
     foreach($data_to->$key as $pkg) {
         if (! array_key_exists($pkg->name, $pkgs)) {
-            $pkgs[$pkg->name] = array('NEW', version($pkg), '');
+            $pkgs[$pkg->name] = array('NEW', version($pkg), '', array('direct' => property_exists($pkg, 'direct')));
             continue;
         }
 
@@ -61,6 +61,9 @@ function diff($key, $data_from, $data_to) {
         } else {
             $pkgs[$pkg->name][1] = version($pkg);
             $pkgs[$pkg->name][2] = makeCompareUrl($pkg, $pkgs);
+            if ($pkgs[$pkg->name][3]['direct'] === false) { // Don't overwrite direct if it was already set to true
+                $pkgs[$pkg->name][3]['direct'] = property_exists($pkg, 'direct');
+            }
         }
     }
 
@@ -101,7 +104,7 @@ function tableize($header, $data, $opts = array()) {
 
     $widths = array(maxLength(array_merge(array($header), array_keys($data))));
 
-    $count = count(reset($data));
+    $count = 3; // it will always be 3. The fourth item is a properties array
     for($i = 0; $i < $count; $i++) {
         $widths[] = max(strlen($titles[$i + 1]), maxLength(array_map(function($k) use ($data, $i) { return $data[$k][$i]; }, array_keys($data))));
     }
@@ -113,8 +116,18 @@ function tableize($header, $data, $opts = array()) {
     $lines[] = tabelizeLine($titles, $widths);
     $lines[] = separatorLine($widths, $opts['joint']);
 
+    $lines[] = fillLine(array("Direct"), '~', $widths);
+
     foreach($data as $key => $v) {
-        $lines[] = tabelizeLine(array_merge(array($key), $v), $widths);
+        if (! $v[3]['direct']) continue;
+        $lines[] = tabelizeLine(array_merge(array($key), array_slice($v, 0, $count)), $widths);
+    }
+
+    $lines[] = fillLine(array("Indirect"), '~', $widths);
+
+    foreach($data as $key => $v) {
+        if ($v[3]['direct']) continue;
+        $lines[] = tabelizeLine(array_merge(array($key), array_slice($v, 0, $count)), $widths);
     }
 
     if ($opts['capped']) {
@@ -130,6 +143,19 @@ function separatorLine($widths, $joint) {
 
 function maxLength(array $array) {
     return max(array_map('strlen', $array));
+}
+
+function fillLine($data, $fill_char, $widths) {
+    $count = count($data);
+    for ($i = 0; $i < count($widths); $i++) {
+        if ($i < $count) {
+            $data[$i] = $fill_char . " " . $data[$i] . " " . str_repeat($fill_char, $widths[$i] - (strlen($data[$i]) + 3));
+        } else {
+            $data[$i] = str_repeat($fill_char, $widths[$i]);
+        }
+    }
+
+    return tabelizeLine($data, $widths);
 }
 
 function tabelizeLine($data, $widths) {
@@ -209,11 +235,20 @@ function loadFile($fileish, $base_path, $default_fileish) {
     }
 
     // Is it a file in the local filesystem?
-    if (file_exists($fileish)) {
-        return array(mustDecodeJson(file_get_contents($fileish), $fileish), false);
+    if (! file_exists($fileish)) {
+        return array(false, "Candidate '$fileish' does not look loadable from the fs or php stream wrappers");
     }
 
-    return array(false, "Candidate '$fileish' does not look loadable from the fs or php stream wrappers");
+    $data = mustDecodeJson(file_get_contents($fileish), $fileish);
+
+    // Try to load composer.json and mark deps.
+    if (substr($fileish, -4) == "lock") {
+        $composer_json_fileish = substr($fileish, 0, -4) . 'json';
+        $composer_json = mustDecodeJson(file_get_contents($composer_json_fileish), $composer_json_fileish);
+        markDirectDependencies($data, $composer_json);
+    }
+
+    return array($data, false);
 }
 
 function isUrl($string) {
@@ -229,6 +264,26 @@ function mustDecodeJson($json, $context) {
     }
 
     return $data;
+}
+
+function markDirectDependencies($lock, $json) {
+    foreach (array('', '-dev') as $ext) {
+        foreach ($json->{'require'.$ext} as $pkg => $_) {
+            $packages = 'packages'.$ext;
+
+            $index = false;
+            for($i = 0; $i < count($lock->{$packages}); $i++) {
+                if ($lock->{$packages}[$i]->name == $pkg) {
+                    $index = $i;
+                    break;
+                }
+            }
+
+            if ($index !== false) {
+                $lock->{$packages}[$i]->direct = true;
+            }
+        }
+    }
 }
 
 function makeCompareUrl($pkg, $diff) {

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -34,12 +34,21 @@ if ($opts['md']) {
 }
 
 $table_titles = array(
-    'changes' => 'Production Changes',
-    'changes-dev' => 'Dev Changes',
+    true => array(
+        'changes' => 'Production Changes',
+        'changes-dev' => 'Dev Changes',
+    ),
+    false => array(
+        'changes' => 'Indirect Production Changes',
+        'changes-dev' => 'Indirect Dev Changes',
+    )
 );
 
-foreach($changes as $k => $diff) {
-    print tableize($table_titles[$k], $diff, $table_opts);
+foreach(array(true, false) as $direct) {
+    foreach($changes as $k => $diff) {
+        $diff = filterDirect($diff, $direct);
+        print tableize($table_titles[$direct][$k], $diff, $table_opts);
+    }
 }
 
 function diff($key, $data_from, $data_to) {
@@ -68,6 +77,18 @@ function diff($key, $data_from, $data_to) {
     }
 
     return $pkgs;
+}
+
+function filterDirect($diff, $direct)
+{
+    if (empty($diff)) return $diff;
+
+    $filtered = array();
+    foreach($diff as $key => $v) {
+        if ($v[3]['direct'] != $direct) continue;
+        $filtered[$key] = $v;
+    }
+    return $filtered;
 }
 
 function version($pkg)
@@ -104,7 +125,7 @@ function tableize($header, $data, $opts = array()) {
 
     $widths = array(maxLength(array_merge(array($header), array_keys($data))));
 
-    $count = 3; // it will always be 3. The fourth item is a properties array
+    $count = count(reset($data)) - 1;
     for($i = 0; $i < $count; $i++) {
         $widths[] = max(strlen($titles[$i + 1]), maxLength(array_map(function($k) use ($data, $i) { return $data[$k][$i]; }, array_keys($data))));
     }
@@ -116,17 +137,7 @@ function tableize($header, $data, $opts = array()) {
     $lines[] = tabelizeLine($titles, $widths);
     $lines[] = separatorLine($widths, $opts['joint']);
 
-    $lines[] = fillLine(array("Direct"), '~', $widths);
-
     foreach($data as $key => $v) {
-        if (! $v[3]['direct']) continue;
-        $lines[] = tabelizeLine(array_merge(array($key), array_slice($v, 0, $count)), $widths);
-    }
-
-    $lines[] = fillLine(array("Indirect"), '~', $widths);
-
-    foreach($data as $key => $v) {
-        if ($v[3]['direct']) continue;
         $lines[] = tabelizeLine(array_merge(array($key), array_slice($v, 0, $count)), $widths);
     }
 
@@ -547,4 +558,3 @@ EOF;
     exit($status);
 }
 # vim: ff=unix ts=4 ss=4 sr et
-


### PR DESCRIPTION
When having huge dependency lists, separate tables for direct and indirect dependencies are helpful - you see which changes were desired, and which ones came only automatically.

Having direct prod+dev changes first eases seeing wanted changes.

Builds upon https://github.com/davidrjonas/composer-lock-diff/pull/41
Resolves: https://github.com/davidrjonas/composer-lock-diff/issues/37

# Short example
```
$ composer-lock-diff --no-links
+------------------------------------+-------------+-----------------------+
| Production Changes                 | From        | To                    |
+------------------------------------+-------------+-----------------------+
| andersundsehr/aus-driver-amazon-s3 | 1.12.1      | 1.13.1                |
| felixnagel/generic-gallery         | 4.3.0       | 5.2.0                 |
| fluidtypo3/flux                    | 9.7.2       | 9.7.4                 |
+------------------------------------+-------------+-----------------------+

+-------------------+---------+---------+
| Dev Changes       | From    | To      |
+-------------------+---------+---------+
| mogic/mogic-phpcs | d81fefd | 0eb8337 |
+-------------------+---------+---------+

+------------------------------------+---------+---------+
| Indirect Production Changes        | From    | To      |
+------------------------------------+---------+---------+
| aws/aws-crt-php                    | v1.0.2  | v1.2.7  |
| aws/aws-sdk-php                    | 3.255.7 | 3.331.0 |
| beberlei/assert                    | v3.3.2  | v3.3.3  |
| clue/stream-filter                 | v1.6.0  | v1.7.0  |
+------------------------------------+---------+---------+

+----------------------+---------+---------+
| Indirect Dev Changes | From    | To      |
+----------------------+---------+---------+
| phpstan/phpstan      | 1.12.10 | 1.12.11 |
+----------------------+---------+---------+
```

# Long example
Real world
```
$ composer-lock-diff --no-links
+------------------------------------+-------------+-----------------------+
| Production Changes                 | From        | To                    |
+------------------------------------+-------------+-----------------------+
| andersundsehr/aus-driver-amazon-s3 | 1.12.1      | 1.13.1                |
| felixnagel/generic-gallery         | 4.3.0       | 5.2.0                 |
| fluidtypo3/flux                    | 9.7.2       | 9.7.4                 |
| fluidtypo3/vhs                     | 6.1.2       | 6.1.3                 |
| helhum/typo3-console               | v6.7.6      | v7.1.6                |
| jigal/t3adminer                    | 10.0.1      | 12.1.0                |
| mogic/t3x-nh2020                   | dev-develop | dev-SRH-1440-typo3v11 |
| mogic/t3x-srh                      | dev-develop | dev-SRH-1440-typo3v11 |
| mogic/t3x-srh-service              | dev-develop | dev-SRH-1440-typo3v11 |
| ssch/typo3-encore                  | v5.0.2      | v5.0.7                |
| symfony/webpack-encore-bundle      | v1.16.0     | v1.17.2               |
| tomasnorre/crawler                 | 11.0.7      | 11.0.10               |
| typo3/cms-backend                  | v10.4.37    | v11.5.41              |
| typo3/cms-belog                    | v10.4.37    | v11.5.41              |
| typo3/cms-beuser                   | v10.4.37    | v11.5.41              |
| typo3/cms-core                     | v10.4.37    | v11.5.41              |
| typo3/cms-extbase                  | v10.4.37    | v11.5.41              |
| typo3/cms-extensionmanager         | v10.4.37    | v11.5.41              |
| typo3/cms-felogin                  | v10.4.37    | v11.5.41              |
| typo3/cms-filelist                 | v10.4.37    | v11.5.41              |
| typo3/cms-filemetadata             | v10.4.37    | v11.5.41              |
| typo3/cms-fluid                    | v10.4.37    | v11.5.41              |
| typo3/cms-fluid-styled-content     | v10.4.37    | v11.5.41              |
| typo3/cms-form                     | v10.4.37    | v11.5.41              |
| typo3/cms-frontend                 | v10.4.37    | v11.5.41              |
| typo3/cms-impexp                   | v10.4.37    | v11.5.41              |
| typo3/cms-indexed-search           | v10.4.37    | v11.5.41              |
| typo3/cms-info                     | v10.4.37    | v11.5.41              |
| typo3/cms-install                  | v10.4.37    | v11.5.41              |
| typo3/cms-lowlevel                 | v10.4.37    | v11.5.41              |
| typo3/cms-recordlist               | v10.4.37    | v11.5.41              |
| typo3/cms-redirects                | v10.4.37    | v11.5.41              |
| typo3/cms-rte-ckeditor             | v10.4.37    | v11.5.41              |
| typo3/cms-scheduler                | v10.4.37    | v11.5.41              |
| typo3/cms-seo                      | v10.4.37    | v11.5.41              |
| typo3/cms-setup                    | v10.4.37    | v11.5.41              |
| typo3/cms-sys-note                 | v10.4.37    | v11.5.41              |
| typo3/cms-t3editor                 | v10.4.37    | v11.5.41              |
| typo3/cms-tstemplate               | v10.4.37    | v11.5.41              |
| typo3/cms-viewpage                 | v10.4.37    | v11.5.41              |
| typo3/cms-workspaces               | v10.4.37    | v11.5.41              |
+------------------------------------+-------------+-----------------------+

+-------------------+---------+---------+
| Dev Changes       | From    | To      |
+-------------------+---------+---------+
| mogic/mogic-phpcs | d81fefd | 0eb8337 |
+-------------------+---------+---------+

+------------------------------------+---------+---------+
| Indirect Production Changes        | From    | To      |
+------------------------------------+---------+---------+
| aws/aws-crt-php                    | v1.0.2  | v1.2.7  |
| aws/aws-sdk-php                    | 3.255.7 | 3.331.0 |
| beberlei/assert                    | v3.3.2  | v3.3.3  |
| clue/stream-filter                 | v1.6.0  | v1.7.0  |
| composer/semver                    | 3.3.2   | 3.4.3   |
| doctrine/annotations               | 1.14.3  | 1.14.4  |
| doctrine/deprecations              | v1.1.1  | 1.1.3   |
| egulias/email-validator            | 2.1.25  | 3.2.6   |
| enshrined/svg-sanitize             | 0.15.4  | 0.18.0  |
| guzzlehttp/guzzle                  | 6.5.8   | 7.9.2   |
| guzzlehttp/promises                | 1.5.3   | 2.0.4   |
| guzzlehttp/psr7                    | 1.9.1   | 2.7.0   |
| jean85/pretty-package-versions     | 2.0.5   | 2.1.0   |
| lolli42/finediff                   | 1.0.2   | 1.0.4   |
| masterminds/html5                  | 2.8.0   | 2.9.0   |
| mtdowling/jmespath.php             | 2.6.1   | 2.8.0   |
| php-http/client-common             | 2.6.0   | 2.7.2   |
| php-http/discovery                 | 1.14.3  | 1.20.0  |
| php-http/httplug                   | 2.3.0   | 2.4.1   |
| php-http/message                   | 1.13.0  | 1.16.2  |
| php-http/message-factory           | v1.0.2  | 1.1.0   |
| php-http/promise                   | 1.1.0   | 1.3.1   |
| phpdocumentor/reflection-docblock  | 5.3.0   | 5.6.0   |
| phpdocumentor/type-resolver        | 1.7.2   | 1.10.0  |
| phpstan/phpdoc-parser              | 1.23.0  | 1.33.0  |
| psr/http-client                    | 1.0.2   | 1.0.3   |
| psr/http-factory                   | 1.0.2   | 1.1.0   |
| sentry/sdk                         | 3.3.0   | 3.6.0   |
| sentry/sentry                      | 3.12.0  | 3.22.1  |
| symfony/asset                      | v5.4.13 | v5.4.45 |
| symfony/cache                      | v5.4.25 | v5.4.46 |
| symfony/cache-contracts            | v2.5.2  | v2.5.4  |
| symfony/config                     | v5.4.21 | v5.4.46 |
| symfony/dependency-injection       | v5.4.25 | v5.4.48 |
| symfony/deprecation-contracts      | v2.5.3  | v2.5.4  |
| symfony/error-handler              | v5.4.17 | v5.4.46 |
| symfony/event-dispatcher           | v5.4.22 | v5.4.45 |
| symfony/event-dispatcher-contracts | v2.5.2  | v2.5.4  |
| symfony/expression-language        | v5.4.21 | v5.4.45 |
| symfony/http-client                | v5.4.17 | v5.4.48 |
| symfony/http-client-contracts      | v2.5.2  | v2.5.4  |
| symfony/http-foundation            | v5.4.25 | v5.4.48 |
| symfony/http-kernel                | v5.4.18 | v5.4.48 |
| symfony/mailer                     | v5.4.22 | v5.4.45 |
| symfony/mime                       | v5.4.23 | v5.4.45 |
| symfony/options-resolver           | v5.4.11 | v5.4.45 |
| symfony/polyfill-intl-icu          | v1.27.0 | v1.31.0 |
| symfony/polyfill-intl-idn          | v1.27.0 | v1.31.0 |
| symfony/polyfill-php72             | v1.27.0 | REMOVED |
| symfony/property-access            | v5.4.22 | v5.4.45 |
| symfony/property-info              | v5.4.24 | v5.4.48 |
| symfony/routing                    | v5.4.25 | v5.4.48 |
| symfony/service-contracts          | v2.5.3  | v2.5.4  |
| symfony/var-dumper                 | v5.4.17 | v5.4.48 |
| symfony/var-exporter               | v5.4.21 | v5.4.45 |
| symfony/web-link                   | v5.4.3  | v5.4.45 |
| typo3/class-alias-loader           | v1.1.4  | v1.2.0  |
| typo3/cms-cli                      | 2.0.0   | 3.1.2   |
| typo3/cms-composer-installers      | v3.1.3  | v3.1.4  |
| typo3/html-sanitizer               | v2.1.1  | v2.2.0  |
| bacon/bacon-qr-code                | NEW     | 2.0.8   |
| christian-riesen/base32            | NEW     | 1.6.0   |
| dasprid/enum                       | NEW     | 1.0.6   |
| helhum/php-error-reporting         | NEW     | v1.0.1  |
| symfony/lock                       | NEW     | v5.4.45 |
| symfony/polyfill-php83             | NEW     | v1.31.0 |
| symfony/rate-limiter               | NEW     | v5.4.47 |
+------------------------------------+---------+---------+

+----------------------+---------+---------+
| Indirect Dev Changes | From    | To      |
+----------------------+---------+---------+
| phpstan/phpstan      | 1.12.10 | 1.12.11 |
+----------------------+---------+---------+
```