### PR TITLE
Exit in error if VCS cannot be forced, closes #47

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 OPTS ?= ""
+PHP = php
 
 all: test md no-links only-dev only-prod json json-pretty
 
 test:
-	php ./composer-lock-diff --from test-data/composer.from.lock --to test-data/composer.to.lock $(OPTS)
+	$(PHP) ./composer-lock-diff --from test-data/composer.from.lock --to test-data/composer.to.lock $(OPTS)
 
 md:
 	$(MAKE) test OPTS=--md

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 OPTS ?= ""
 PHP = php
 
-all: test md no-links only-dev only-prod json json-pretty
+all: test test-help test-help-vcs-error md no-links only-dev only-prod json json-pretty
 
 test:
 	$(PHP) ./composer-lock-diff --from test-data/composer.from.lock --to test-data/composer.to.lock $(OPTS)
+
+test-help:
+	$(PHP) ./composer-lock-diff --help
+
+test-help-vcs-error:
+	$(PHP) ./composer-lock-diff --vcs UNKNOWN ; test $$? -eq 1
 
 md:
 	$(MAKE) test OPTS=--md

--- a/README.md
+++ b/README.md
@@ -38,16 +38,18 @@ Or from vim, to insert the output into the commit message, type `:r!composer-loc
 
 ### Options
 
-- `--path, -p`: Base to with which to prefix paths. Default "./"
-- `--from`: The file^, git ref, or git ref with filename to compare from (HEAD:composer.lock)
+- `-h, --help`: Print this message
+- `-p, --path`: Base to with which to prefix paths. Default "./"  
+  E.g. `-p app` would look for HEAD:app/composer.lock and app/composer.lock
+- `--from`: The file^, git ref, or git ref with filename to compare from (git: HEAD:composer.lock, svn: composer.lock@BASE)
 - `--to`: The file^, git ref, or git ref with filename to compare to (composer.lock)
-- `--md`: Markdown table output
-- `--json`: json output
-- `--pretty`: pretty output when combined with `--json` (>=5.4 only)
+- `--json`: Format output as JSON
+- `--pretty`: Pretty print JSON output (PHP >= 5.4.0)
+- `--md`: Use markdown instead of plain text
 - `--no-links`: Don't include Compare links in plain text or any links in markdown
 - `--only-prod`: Only include changes from `packages`
 - `--only-dev`: Only include changes from `packages-dev`
-- `--vcs`: Force vcs (git, svn, ...). Default auto-detect from path
+- `--vcs`: Force vcs (git, svn, ...). Default: attempt to auto-detect
 
 ^ File includes anything available as a [protocol stream wrapper](http://php.net/manual/en/wrappers.php) such as URLs.
 

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -69,7 +69,7 @@ function diff($key, $data_from, $data_to) {
 
 function version($pkg)
 {
-    if((substr($pkg->version,0,4) == 'dev-' || '-dev' === substr($pkg->version, -4)) && isset($pkg->source) && isset($pkg->source->reference)) {
+    if((substr($pkg->version,0,4) == 'dev-' || '-dev' === substr($pkg->version, -4)) && isset($pkg->source->reference)) {
         $version = substr($pkg->source->reference,0,7) ?: '';
     } else {
         $version = (string) $pkg->version;

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -16,7 +16,7 @@ if (! $opts['only-prod']) {
 }
 
 if ($opts['json']) {
-    $json_opts = ($opts['pretty']) ? JSON_PRETTY_PRINT : 0;
+    $json_opts = ($opts['pretty']) ? JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT : 0;
     echo json_encode($changes, $json_opts), PHP_EOL;
     return;
 }

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -444,8 +444,8 @@ function parseOpts() {
 
     $vcs = array_key_exists('vcs', $given) ? $given['vcs'] : '';
     if ($vcs && !function_exists('vcsLoad' . ucfirst($vcs))) {
-        error_log("Unsupported vcs '$vcs'\n");
-        usage();
+        error_log(sprintf("Unsupported VCS '$vcs'; supported are: '%s'\n", implode("', '", getVcses())));
+        usage(1);
     }
 
     return array(
@@ -462,9 +462,9 @@ function parseOpts() {
     );
 }
 
-function usage() {
+function usage($status = 0) {
     $vcses = implode(', ', getVcses());
-    print <<<EOF
+    $help = <<<EOF
 Usage: composer-lock-diff [options]
 
 Options:
@@ -480,11 +480,16 @@ Options:
   --no-links   Don't include Compare links in plain text or any links in markdown
   --only-prod  Only include changes from `packages`
   --only-dev   Only include changes from `packages-dev`
-  --vcs        Force vcs ($vcses). Default: attempt to auto-detect
-
+  --vcs        Force VCS ($vcses). Default: attempt to auto-detect
 EOF;
 
-    exit(0);
+    if ($status) {
+        error_log($help);
+    } else {
+        echo $help, "\n";
+    }
+
+    exit($status);
 }
 # vim: ff=unix ts=4 ss=4 sr et
 

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -17,7 +17,7 @@ if (! $opts['only-prod']) {
 
 if ($opts['json']) {
     $json_opts = ($opts['pretty']) ? JSON_PRETTY_PRINT : 0;
-    print json_encode($changes, $json_opts);
+    echo json_encode($changes, $json_opts), PHP_EOL;
     return;
 }
 

--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -468,8 +468,8 @@ function usage() {
 Usage: composer-lock-diff [options]
 
 Options:
-  -h --help    Print this message
-  --path, -p   Base to with which to prefix paths. Default "./"
+  -h, --help   Print this message
+  -p, --path   Base to with which to prefix paths. Default "./"
                E.g. `-p app` would look for HEAD:app/composer.lock and app/composer.lock
   --from       The file, git ref, or git ref with filename to compare from
                (git: HEAD:composer.lock, svn: composer.lock@BASE)

--- a/test-svn.sh
+++ b/test-svn.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+DIR="$( CDPATH='' cd -- "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+[ "$DIR" ] || exit
 
 svn --help > /dev/null || { echo "Fail: could not find 'svn' executable"; exit 1; }
 svnadmin --help > /dev/null || { echo "Fail: could not find 'svnadmin' executable"; exit 1; }
@@ -8,7 +9,7 @@ svnadmin --help > /dev/null || { echo "Fail: could not find 'svnadmin' executabl
 trap cleanup INT ERR
 
 function cleanup() {
-  cd "$DIR/test-data"
+  cd "$DIR/test-data" || exit
   rm -rf proj proj-working svnrepo
 }
 


### PR DESCRIPTION
Patch for #47.

Also addresses some by-catches we ran over during testing.